### PR TITLE
Add navigation design and subsection example

### DIFF
--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { PureComponent } from 'react'
 import PointsCounter from '../PointsCounter'
-import { Nav, Section } from './style'
+import { Nav, Section, SubSection } from './style'
 import NavigationItem from '../NavigationItem'
 
 class Navigation extends PureComponent {
@@ -18,6 +18,41 @@ class Navigation extends PureComponent {
             </li>
             <li>
               <NavigationItem href="/srp/intro">Принцип единственной ответственности</NavigationItem>
+
+              <SubSection>
+                <ul>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Введение и понятия
+                    </NavigationItem>
+                  </li>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Примеры из идеального мира
+                    </NavigationItem>
+                  </li>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Примеры из реальной жизни
+                    </NavigationItem>
+                  </li>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Шаблоны проектирования и приёмы рефакторинга
+                    </NavigationItem>
+                  </li>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Антипаттерны
+                    </NavigationItem>
+                  </li>
+                  <li>
+                    <NavigationItem href="/" depth={2}>
+                      Ограничения и подводные камни
+                    </NavigationItem>
+                  </li>
+                </ul>
+              </SubSection>
             </li>
             <li>
               <NavigationItem href="/open-closed/intro">Принцип открытости и закрытости</NavigationItem>

--- a/components/Navigation/style.ts
+++ b/components/Navigation/style.ts
@@ -45,3 +45,7 @@ export const Section = styled.div`
     margin: 0.8em 0;
   }
 `
+
+export const SubSection = styled.div`
+  padding-left: 1em;
+`

--- a/components/NavigationItem/NavigationItem.tsx
+++ b/components/NavigationItem/NavigationItem.tsx
@@ -1,19 +1,25 @@
 import * as React from 'react'
+import clsx from 'clsx'
 import { PureComponent } from 'react'
 import Link from 'next/link'
 import Container from './style'
 
 interface Props {
   href: string
+  depth: number
   children: React.ReactChild
 }
 
 class NavigationItem extends PureComponent<Props> {
+  static defaultProps = {
+    depth: 1
+  }
+
   render() {
-    const { href, children } = this.props
+    const { href, children, depth } = this.props
     return (
-      // TODO: replace stub with real functionality
-      <Container className={href === '/' ? 'active' : ''}>
+      // TODO: replace stub (href === '/srp/info') with real functionality
+      <Container className={clsx({ active: href === '/srp/intro' }, { deep: depth > 1 })}>
         <Link href={href}>
           <a>{children}</a>
         </Link>

--- a/components/NavigationItem/style.ts
+++ b/components/NavigationItem/style.ts
@@ -22,4 +22,8 @@ export default styled.div`
   &.active::before {
     background: black;
   }
+
+  &.deep::before {
+    display: none;
+  }
 `


### PR DESCRIPTION
resolves https://github.com/open-tech-authors/solid/issues/12

Сделал пример с подсекцией в навигационном меню, которая появляется, если мы находимся в разделе, у которого подсекция есть. 

Добавил туда настоящие ссылки из раздела, насколько я понимаю, это будет финальное количество подразделов внутри. Вроде вмещается всё, у меня 13 дюймов экран, масштаб уменьшенный правда:
<img width="1108" alt="«Screenshot» 2019-03-13 at 18 45 26" src="https://user-images.githubusercontent.com/9102374/54298028-b1c49a80-45c0-11e9-8a42-f9f0443ae9e8.png">

А вот пример, когда активный раздел без подсекций:
<img width="1057" alt="«Screenshot» 2019-03-13 at 18 46 12" src="https://user-images.githubusercontent.com/9102374/54298138-dfa9df00-45c0-11e9-811f-79ce7e665330.png">

Что думаешь про меню? @dex157 
Что стоит поменять?