### PR TITLE
SRP: Исправление опечатки и сокращение примера

### DIFF
--- a/components/Quiz/quizzes/isp-patterns-2/variant-1.mdx
+++ b/components/Quiz/quizzes/isp-patterns-2/variant-1.mdx
@@ -1,11 +1,11 @@
 1.
 ```ts
 class EventEmitterAdapter extends EventEmitter {
-  private adaptee: Adaptee;
+  private adaptee: Adaptee
 
   constructor(adaptee: Adaptee) {
-    super();
-    this.adaptee = adaptee;
+    super()
+    this.adaptee = adaptee
   }
 
   public emit(e: EventTypes): string {

--- a/components/Quiz/quizzes/isp-patterns-2/variant-2.mdx
+++ b/components/Quiz/quizzes/isp-patterns-2/variant-2.mdx
@@ -1,11 +1,11 @@
 2.
 ```ts
 class LoggerAdapter extends Logger {
-  private adaptee: Adaptee;
+  private adaptee: Adaptee
 
   constructor(adaptee: Adaptee) {
-    super();
-    this.adaptee = adaptee;
+    super()
+    this.adaptee = adaptee
   }
 
   public logEvent(eventType: string): void {

--- a/components/Quiz/quizzes/srp-patterns-6/question.mdx
+++ b/components/Quiz/quizzes/srp-patterns-6/question.mdx
@@ -1,11 +1,13 @@
 Что можно вынести за фасад из примера ниже?
 
 ```ts
-enum PlayerTypes = { Audio, Video }
+enum PlayerTypes { Audio, Video }
 
-class Player implements Player {
+class Player implements IPlayer {
+  player: AnyPlayer
+
   constructor(playerType: PlayerTypes) {
-    this.player = playerType === PlayerTypes.audio
+    this.player = playerType === PlayerTypes.Audio
       ? new AudioPlayer()
       : new VideoPlayer()
   }

--- a/pages/dip/in-real-life.mdx
+++ b/pages/dip/in-real-life.mdx
@@ -19,7 +19,7 @@ export default ({ children }) => <MainLayout meta={meta}>{children}</MainLayout>
 
 ```ts
 describe('Auth', () => {
-  let connection: MySqlConnection;
+  let connection: MySqlConnection
   let auth: Auth
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ class DbMock implements DataBaseConnection {
 }
 
 describe('Auth', () => {
-  let connection: DataBaseConnection;
+  let connection: DataBaseConnection
   let auth: Auth
 
   beforeEach(() => {

--- a/pages/isp/in-real-life.mdx
+++ b/pages/isp/in-real-life.mdx
@@ -27,9 +27,9 @@ ISP можно рассматривать, как [SRP](/srp) для интер�
 
 ```ts
 interface Spend {
-  amount: number;
-  date: Timestamp;
-  type: 'helpful' | 'harmful' | null;
+  amount: number
+  date: Timestamp
+  type: 'helpful' | 'harmful' | null
 }
 
 type History = Spend[]
@@ -45,16 +45,16 @@ type SpendTypes = 'helpful' | 'harmful' | null
 // ISP помогает выявить скрытые связи между сущностями
 // и зависимости в их поведении
 interface Record {
-  amount: number;
-  date: Timestamp;
-  is: RecordTypes;
+  amount: number
+  date: Timestamp
+  is: RecordTypes
   // поля type здесь уже нет,
   // для доходов оно не нужно
 }
 
 // интерфейс траты расширяет интерфейс записи
 interface Spend extends Record {
-  type: SpendTypes;
+  type: SpendTypes
 }
 ```
 
@@ -67,8 +67,8 @@ class RecordItem implements Record {
   is: RecordTypes
 
   constructor(amount: number) {
-    this.amount = amount;
-    this.date = Date.now();
+    this.amount = amount
+    this.date = Date.now()
   }
 }
 
@@ -76,16 +76,16 @@ class SpendItem extends RecordItem implements Spend {
   type: SpendTypes
 
   constructor(amount: number, type: SpendTypes = null) {
-    super(amount);
-    this.is = 'spend';
-    this.type = type;
+    super(amount)
+    this.is = 'spend'
+    this.type = type
   }
 }
 
 class IncomeItem extends RecordItem {
   constructor(amount: number) {
-    super(amount);
-    this.is = 'income';
+    super(amount)
+    this.is = 'income'
   }
 }
 ```

--- a/pages/isp/patterns.mdx
+++ b/pages/isp/patterns.mdx
@@ -75,16 +75,16 @@ class Horse implements Animal, Transport {/*...*/}
 function applyMixins(derivedCtor: any, baseCtors: any[]) {
   baseCtors.forEach(baseCtor => {
     Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
-      Object.defineProperty(derivedCtor.prototype, name, Object.getOwnPropertyDescriptor(baseCtor.prototype, name));
-    });
-  });
+      Object.defineProperty(derivedCtor.prototype, name, Object.getOwnPropertyDescriptor(baseCtor.prototype, name))
+    })
+  })
 }
 ```
 
 Чтобы пример с классом `Horse` выше сработал, нам необходимо использовать `applyMixins` следующим образом:
 
 ```ts
-applyMixins(Horse, [Animal, Transport]);
+applyMixins(Horse, [Animal, Transport])
 ```
 
 Тогда множественное наследование будет работать, как мы ожидаем.

--- a/pages/lsp/index.mdx
+++ b/pages/lsp/index.mdx
@@ -48,7 +48,7 @@ class Square extends Rectangle {
   height: number
 
   constructor(size: number) {
-    super(size, size);
+    super(size, size)
   }
 
   setWidth(width: number) {

--- a/pages/ocp/in-ideal-world.mdx
+++ b/pages/ocp/in-ideal-world.mdx
@@ -57,10 +57,6 @@ class Circle {
   constructor(radius: number) {
     this.radius = radius
   }
-
-  areaOf(): number {
-    return Math.PI * (this.radius ** 2)
-  }
 }
 
 class AreaCalculator {

--- a/pages/srp/in-ideal-world.mdx
+++ b/pages/srp/in-ideal-world.mdx
@@ -55,7 +55,7 @@ class ReportExporter {
 
 ```ts
 interface Formatter {
-  format(data: ReportData): string;
+  format(data: ReportData): string
 }
 
 // класс для форматирования в HTML

--- a/pages/srp/in-ideal-world.mdx
+++ b/pages/srp/in-ideal-world.mdx
@@ -43,8 +43,8 @@ class ReportExporter {
   }
 
   export(reportType: ReportTypes): string {
-    const formatter: Formatter = new FormatSelector(reportType, this.data)
-    return formatter.format()
+    const formatter: Formatter = new FormatSelector(reportType)
+    return formatter.format(this.data)
   }
 }
 ```

--- a/pages/srp/patterns.mdx
+++ b/pages/srp/patterns.mdx
@@ -22,14 +22,14 @@ export default ({ children }) => <MainLayout meta={meta}>{children}</MainLayout>
 ```ts
 // до рефакторинга
 class Person {
-  name: string;
-  phone: string;
-  officeCode: string;
+  name: string
+  phone: string
+  officeCode: string
 
   constructor(name: string, phone: string, officeCode: string) {
-    this.name = name;
-    this.phone = phone;
-    this.officeCode = officeCode;
+    this.name = name
+    this.phone = phone
+    this.officeCode = officeCode
   }
 
   phoneNumberOf(): string {
@@ -38,9 +38,9 @@ class Person {
 }
 
 // после
-interface PhoneNumber {
-  phone: string;
-  officeCode: string;
+interface IPhoneNumber {
+  phone: string
+  officeCode: string
   valueOf(): string
 }
 
@@ -49,8 +49,8 @@ class PhoneNumber implements IPhoneNumber {
   officeCode: string
 
   constructor(phone: string, officeCode: string) {
-    this.phone = phone;
-    this.officeCode = officeCode;
+    this.phone = phone
+    this.officeCode = officeCode
   }
 
   valueOf(): string {
@@ -59,11 +59,11 @@ class PhoneNumber implements IPhoneNumber {
 }
 
 class Person {
-  name: string;
-  phoneNumber: IPhoneNumber;
+  name: string
+  phoneNumber: IPhoneNumber
 
   constructor(name: string, phoneNumber: IPhoneNumber) {
-    this.name = name;
+    this.name = name
     this.phoneNumber = phoneNumber
   }
 

--- a/pages/srp/patterns.mdx
+++ b/pages/srp/patterns.mdx
@@ -44,9 +44,9 @@ interface PhoneNumber {
   valueOf(): string
 }
 
-class PhoneNumber implements PhoneNumber {
-  phone: string;
-  officeCode: string;
+class PhoneNumber implements IPhoneNumber {
+  phone: string
+  officeCode: string
 
   constructor(phone: string, officeCode: string) {
     this.phone = phone;
@@ -60,9 +60,9 @@ class PhoneNumber implements PhoneNumber {
 
 class Person {
   name: string;
-  phoneNumber: PhoneNumber;
+  phoneNumber: IPhoneNumber;
 
-  constructor(name: string, phoneNumber: PhoneNumber) {
+  constructor(name: string, phoneNumber: IPhoneNumber) {
     this.name = name;
     this.phoneNumber = phoneNumber
   }


### PR DESCRIPTION
Привет!

Нашёл опечатку: метод `format()` должен принимать параметр с данными.

Заодно сократил пример класса `ReportExporter`, чтобы убрать шум, акцентируя внимание на сути. Хотя поле `name` вроде как тоже избыточно, но ладно, это можно считать неким именем отчета.