### PR TITLE
Правит избыточное описание типов в примере с React.FunctionComponent

### DIFF
--- a/pages/lsp/in-real-life.mdx
+++ b/pages/lsp/in-real-life.mdx
@@ -161,9 +161,7 @@ interface ComponentProps {
 }
 
 // пример React-компонента
-const ExampleReactComponent: FunctionComponent<ComponentProps> = ({
-  title
-}: ComponentProps): ReactElement => (
+const ExampleReactComponent: FunctionComponent<ComponentProps> = ({ title }): ReactElement => (
   <div>
     <h1>{title}</h1>
     <OtherComponent />

--- a/pages/lsp/in-real-life.mdx
+++ b/pages/lsp/in-real-life.mdx
@@ -161,7 +161,7 @@ interface ComponentProps {
 }
 
 // пример React-компонента
-const ExampleReactComponent: FunctionComponent<ComponentProps> = ({ title }): ReactElement => (
+const ExampleReactComponent: FunctionComponent<ComponentProps> = ({ title }) => (
   <div>
     <h1>{title}</h1>
     <OtherComponent />


### PR DESCRIPTION
Тип `ComponentProps` уже прописан при описании функции: `FunctionComponent<ComponentProps>`, поэтому props уже будут с типом `ComponentProps`. Не имеет смысла указывать это второй раз. Запись, когда `ComponentProps` указывается только один раз - более лаконичная.  

С дублированием типа `ReactElement ` - то же самое: указания `const ExampleReactComponent: FunctionComponent<ComponentProps>` достаточно, переменная и так будет иметь правильный тип, нет смысла дублировать.